### PR TITLE
8.16: update docs, mergify, versions and changelogs

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -359,3 +359,17 @@ pull_request_rules:
         labels:
           - "backport"
         title: "[{{ destination_branch }}] {{ title }} (backport #{{ number }})"
+  - name: backport patches to 8.16 branch
+    conditions:
+      - merged
+      - base=8.x
+      - label=backport-8.16
+    actions:
+      backport:
+        assignees:
+          - "{{ author }}"
+        branches:
+          - "8.16"
+        labels:
+          - "backport"
+        title: "[{{ destination_branch }}] {{ title }} (backport #{{ number }})"

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -1,4 +1,5 @@
 // tag::list[]
+* <<apm-release-notes-8.16>>
 * <<apm-release-notes-8.15>>
 * <<apm-release-notes-8.14>>
 * <<apm-release-notes-8.13>>
@@ -19,6 +20,7 @@
 
 // tag::includes[]
 include::./changelogs/head.asciidoc[]
+include::./changelogs/8.16.asciidoc[]
 include::./changelogs/8.15.asciidoc[]
 include::./changelogs/8.14.asciidoc[]
 include::./changelogs/8.13.asciidoc[]

--- a/changelogs/8.16.asciidoc
+++ b/changelogs/8.16.asciidoc
@@ -1,0 +1,29 @@
+[[apm-release-notes-8.16]]
+== APM version 8.16
+* <<apm-release-notes-8.16.0>>
+
+[float]
+[[apm-release-notes-8.16.0]]
+=== APM version 8.16.0
+
+https://github.com/elastic/apm-server/compare/v8.15.1\...v8.16.0[View commits]
+
+[float]
+==== Bug fixes
+
+- Track all bulk request response status codes {pull}13574[13574]
+
+[float]
+==== Breaking Changes
+
+[float]
+==== Deprecations
+- Support for Jaeger is now deprecated, and will be removed in a future release {pull}13809[13809]
+
+[float]
+==== Intake API Changes
+
+[float]
+==== Added
+
+- APM Server will no longer retry an HTTP request that returned 502s, 503s, 504s. It will only retry 429s. {pull}13523[13523]

--- a/changelogs/head.asciidoc
+++ b/changelogs/head.asciidoc
@@ -1,24 +1,16 @@
 [[release-notes-head]]
 == APM version HEAD
 
-https://github.com/elastic/apm-server/compare/8.15\...main[View commits]
-
-[float]
-==== Bug fixes
-
-- Track all bulk request response status codes {pull}13574[13574]
+https://github.com/elastic/apm-server/compare/8.16\...8.x[View commits]
 
 [float]
 ==== Breaking Changes
 
 [float]
 ==== Deprecations
-- Support for Jaeger is now deprecated, and will be removed in a future release {pull}13809[13809]
 
 [float]
 ==== Intake API Changes
 
 [float]
 ==== Added
-
-- APM Server will no longer retry an HTTP request that returned 502s, 503s, 504s. It will only retry 429s. {pull}13523[13523]

--- a/cmd/intake-receiver/version.go
+++ b/cmd/intake-receiver/version.go
@@ -18,4 +18,4 @@
 package main
 
 // version matches the APM Server's version
-const version = "8.16.0"
+const version = "8.17.0"

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -18,4 +18,4 @@
 package version
 
 // Version holds the APM Server version.
-const Version = "8.16.0"
+const Version = "8.17.0"


### PR DESCRIPTION
Merge as soon as the GitHub checks are green.